### PR TITLE
fix: install Claude Code CLI in workflow

### DIFF
--- a/.github/workflows/kiln.yml
+++ b/.github/workflows/kiln.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       # Dogfood: use the action from this repo itself
       - uses: ./
         with:

--- a/.github/workflows/kiln.yml
+++ b/.github/workflows/kiln.yml
@@ -38,7 +38,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       # Dogfood: use the action from this repo itself
       - uses: ./


### PR DESCRIPTION
## Summary
- Adds `npm install -g @anthropic-ai/claude-code` step to the Kiln workflow before the action runs
- Fixes `claude: not found` error that caused triage to fail on issue #1

## Test plan
- [ ] Merge this PR and re-trigger issue #1 triage (remove and re-add a label, or close/reopen)
- [ ] Verify the `claude` CLI is available and triage succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)