### PR TITLE
feat: triage reopened issues

### DIFF
--- a/.github/workflows/kiln.yml
+++ b/.github/workflows/kiln.yml
@@ -4,7 +4,7 @@ name: "🔥 Kiln"
 on:
   # Triage: classify new issues
   issues:
-    types: [opened, labeled]
+    types: [opened, reopened, labeled]
 
   # Re-triage: re-evaluate after author replies
   issue_comment:

--- a/dist/index.js
+++ b/dist/index.js
@@ -881,15 +881,15 @@ function detectStage(context) {
     if (eventName === "issues") {
         const issueNumber = payload.issue?.number;
         const issueLabels = extractLabels(payload.issue?.labels);
-        // New issue opened → triage
-        if (payload.action === "opened") {
+        // New or reopened issue → triage
+        if (payload.action === "opened" || payload.action === "reopened") {
             const result = {
                 stage: "triage",
                 issueNumber,
                 labels: issueLabels,
                 payload: payload,
             };
-            core.info(`🔥 Kiln Router — Matched stage: triage (issues.opened)`);
+            core.info(`🔥 Kiln Router — Matched stage: triage (issues.${payload.action})`);
             return result;
         }
         // Labeled events — check which label was just added

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -32,6 +32,17 @@ describe("detectStage", () => {
       expect(result!.issueNumber).toBe(42);
       expect(result!.labels).toEqual([]);
     });
+
+    it("returns triage stage for reopened issue", () => {
+      const ctx = makeContext("issues", {
+        action: "reopened",
+        issue: { number: 43, labels: [{ name: "enhancement" }] },
+      });
+      const result = detectStage(ctx);
+      expect(result).not.toBeNull();
+      expect(result!.stage).toBe("triage");
+      expect(result!.issueNumber).toBe(43);
+    });
   });
 
   // ── issue_comment.created → re-triage ─────────────────

--- a/src/router.ts
+++ b/src/router.ts
@@ -25,15 +25,15 @@ export function detectStage(context: Context): RouteResult | null {
     const issueNumber = payload.issue?.number as number | undefined;
     const issueLabels = extractLabels(payload.issue?.labels);
 
-    // New issue opened → triage
-    if (payload.action === "opened") {
+    // New or reopened issue → triage
+    if (payload.action === "opened" || payload.action === "reopened") {
       const result: RouteResult = {
         stage: "triage",
         issueNumber,
         labels: issueLabels,
         payload: payload as unknown as Record<string, unknown>,
       };
-      core.info(`🔥 Kiln Router — Matched stage: triage (issues.opened)`);
+      core.info(`🔥 Kiln Router — Matched stage: triage (issues.${payload.action})`);
       return result;
     }
 


### PR DESCRIPTION
## Summary
- Adds `reopened` to `issues` event types in the workflow so the action fires on reopen
- Updates `router.ts` to route `issues.reopened` to the `triage` stage
- Adds test coverage for the reopened path

Enables re-triggering triage by closing and reopening an issue.

## Test plan
- [ ] Merge, then close and reopen issue #1 to trigger triage
- [ ] Verify triage runs successfully with Claude CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)