### PR TITLE
fix: use GitHub App token for pipeline self-triggering

### DIFF
--- a/.github/workflows/kiln.yml
+++ b/.github/workflows/kiln.yml
@@ -31,11 +31,19 @@ jobs:
   kiln:
     runs-on: ubuntu-latest
     # Don't run on events triggered by Kiln itself
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'datashaman-kiln[bot]'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.KILN_APP_ID }}
+          private-key: ${{ secrets.KILN_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Claude Code CLI
         run: |
@@ -46,3 +54,4 @@ jobs:
       - uses: ./
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Switch from `GITHUB_TOKEN` to a GitHub App installation token (`actions/create-github-app-token@v2`) so that labels applied by the triage stage trigger downstream workflow runs
- Update actor guard from `github-actions[bot]` to `datashaman-kiln[bot]` for loop prevention
- Pass app token to both `actions/checkout` (so pushes trigger CI) and the Kiln action (so API calls trigger workflows)

## Test plan

- [ ] Merge this PR
- [ ] Close and reopen issue #1 to trigger triage
- [ ] Verify triage completes and `kiln:specifying` label triggers a new specify workflow run
- [ ] Verify the pipeline continues through specify → implement → review → ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)