### PR TITLE
fix: pass Claude CLI prompts via stdin

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -130,13 +130,12 @@ const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10MB
 async function invokeClaude(prompt, config) {
     const { anthropicKey, timeoutMinutes = DEFAULT_TIMEOUT_MINUTES, allowEdits = false, octokit, context, } = config;
     const timeoutMs = timeoutMinutes * 60 * 1000;
-    const escapedPrompt = escapeShell(prompt);
     // --print mode = read-only (no file edits); omit for edit mode
-    const command = allowEdits
-        ? `claude "${escapedPrompt}"`
-        : `claude --print "${escapedPrompt}"`;
+    const command = allowEdits ? "claude" : "claude --print";
     try {
+        // Pass prompt via stdin to avoid shell escaping issues with complex input
         const output = (0, child_process_1.execSync)(command, {
+            input: prompt,
             env: {
                 ...process.env,
                 ANTHROPIC_API_KEY: anthropicKey,
@@ -168,7 +167,8 @@ function runClaude(prompt, options) {
     const { anthropicKey, timeoutMinutes = DEFAULT_TIMEOUT_MINUTES } = options;
     const timeoutMs = timeoutMinutes * 60 * 1000;
     try {
-        const output = (0, child_process_1.execSync)(`claude --print "${escapeShell(prompt)}"`, {
+        const output = (0, child_process_1.execSync)("claude --print", {
+            input: prompt,
             env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
             timeout: timeoutMs,
             maxBuffer: MAX_BUFFER_BYTES,
@@ -190,7 +190,8 @@ function runClaudeEdit(prompt, options) {
     const { anthropicKey, timeoutMinutes = DEFAULT_TIMEOUT_MINUTES } = options;
     const timeoutMs = timeoutMinutes * 60 * 1000;
     try {
-        const output = (0, child_process_1.execSync)(`claude "${escapeShell(prompt)}"`, {
+        const output = (0, child_process_1.execSync)("claude", {
+            input: prompt,
             env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
             timeout: timeoutMs,
             maxBuffer: MAX_BUFFER_BYTES,
@@ -250,9 +251,6 @@ function sanitizeOutput(text, apiKey) {
     if (!apiKey)
         return text;
     return text.replace(new RegExp(escapeRegExp(apiKey), "g"), "[REDACTED]");
-}
-function escapeShell(str) {
-    return str.replace(/"/g, '\\"').replace(/\$/g, "\\$").replace(/`/g, "\\`");
 }
 function escapeRegExp(str) {
     return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -78,8 +78,8 @@ describe("invokeClaude", () => {
       });
 
       expect(mockedExecSync).toHaveBeenCalledWith(
-        'claude --print "Review this code"',
-        expect.any(Object),
+        "claude --print",
+        expect.objectContaining({ input: "Review this code" }),
       );
     });
 
@@ -92,8 +92,8 @@ describe("invokeClaude", () => {
       });
 
       expect(mockedExecSync).toHaveBeenCalledWith(
-        'claude "Fix this bug"',
-        expect.any(Object),
+        "claude",
+        expect.objectContaining({ input: "Fix this bug" }),
       );
     });
   });
@@ -337,40 +337,22 @@ describe("invokeClaude", () => {
     });
   });
 
-  describe("prompt escaping", () => {
-    it("escapes double quotes in prompts", async () => {
+  describe("passes prompt via stdin", () => {
+    it("passes prompt as input option, not in command string", async () => {
       mockedExecSync.mockReturnValue("ok");
 
-      await invokeClaude('Say "hello"', { anthropicKey: "sk-ant-test" });
-
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('\\"hello\\"'),
-        expect.any(Object),
-      );
-    });
-
-    it("escapes dollar signs in prompts", async () => {
-      mockedExecSync.mockReturnValue("ok");
-
-      await invokeClaude("Cost is $100", { anthropicKey: "sk-ant-test" });
-
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        expect.stringContaining("\\$100"),
-        expect.any(Object),
-      );
-    });
-
-    it("escapes backticks in prompts", async () => {
-      mockedExecSync.mockReturnValue("ok");
-
-      await invokeClaude("Use `git status`", {
+      await invokeClaude('Say "hello" with $vars and `backticks`', {
         anthropicKey: "sk-ant-test",
       });
 
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        expect.stringContaining("\\`git status\\`"),
-        expect.any(Object),
-      );
+      const callArgs = mockedExecSync.mock.calls[0];
+      const command = callArgs[0] as string;
+      const options = callArgs[1] as { input: string };
+
+      // Prompt must NOT appear in command string
+      expect(command).not.toContain("hello");
+      // Prompt must be passed via stdin input
+      expect(options.input).toBe('Say "hello" with $vars and `backticks`');
     });
   });
 });
@@ -384,12 +366,12 @@ describe("runClaude", () => {
     expect(result).toBe("result");
   });
 
-  it("uses --print mode", () => {
+  it("uses --print mode and passes prompt via stdin", () => {
     mockedExecSync.mockReturnValue("ok");
-    runClaude("prompt", { anthropicKey: "sk-ant-test" });
+    runClaude("test prompt", { anthropicKey: "sk-ant-test" });
     expect(mockedExecSync).toHaveBeenCalledWith(
-      expect.stringContaining("--print"),
-      expect.any(Object),
+      "claude --print",
+      expect.objectContaining({ input: "test prompt" }),
     );
   });
 
@@ -429,11 +411,13 @@ describe("runClaudeEdit", () => {
     expect(result).toBe("result");
   });
 
-  it("does NOT use --print mode (edit mode)", () => {
+  it("does NOT use --print mode and passes prompt via stdin", () => {
     mockedExecSync.mockReturnValue("ok");
-    runClaudeEdit("prompt", { anthropicKey: "sk-ant-test" });
-    const command = mockedExecSync.mock.calls[0][0];
-    expect(command).not.toContain("--print");
+    runClaudeEdit("edit prompt", { anthropicKey: "sk-ant-test" });
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "claude",
+      expect.objectContaining({ input: "edit prompt" }),
+    );
   });
 
   it("throws on CLI failure", () => {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -54,15 +54,14 @@ export async function invokeClaude(
   } = config;
 
   const timeoutMs = timeoutMinutes * 60 * 1000;
-  const escapedPrompt = escapeShell(prompt);
 
   // --print mode = read-only (no file edits); omit for edit mode
-  const command = allowEdits
-    ? `claude "${escapedPrompt}"`
-    : `claude --print "${escapedPrompt}"`;
+  const command = allowEdits ? "claude" : "claude --print";
 
   try {
+    // Pass prompt via stdin to avoid shell escaping issues with complex input
     const output = execSync(command, {
+      input: prompt,
       env: {
         ...process.env,
         ANTHROPIC_API_KEY: anthropicKey,
@@ -103,7 +102,8 @@ export function runClaude(
   const timeoutMs = timeoutMinutes * 60 * 1000;
 
   try {
-    const output = execSync(`claude --print "${escapeShell(prompt)}"`, {
+    const output = execSync("claude --print", {
+      input: prompt,
       env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
       timeout: timeoutMs,
       maxBuffer: MAX_BUFFER_BYTES,
@@ -129,7 +129,8 @@ export function runClaudeEdit(
   const timeoutMs = timeoutMinutes * 60 * 1000;
 
   try {
-    const output = execSync(`claude "${escapeShell(prompt)}"`, {
+    const output = execSync("claude", {
+      input: prompt,
       env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
       timeout: timeoutMs,
       maxBuffer: MAX_BUFFER_BYTES,
@@ -199,10 +200,6 @@ function resolveCommentTarget(context: Context): number | undefined {
 function sanitizeOutput(text: string, apiKey?: string): string {
   if (!apiKey) return text;
   return text.replace(new RegExp(escapeRegExp(apiKey), "g"), "[REDACTED]");
-}
-
-function escapeShell(str: string): string {
-  return str.replace(/"/g, '\\"').replace(/\$/g, "\\$").replace(/`/g, "\\`");
 }
 
 function escapeRegExp(str: string): string {


### PR DESCRIPTION
## Summary
- Pass prompts to the Claude CLI via stdin (`input` option on `execSync`) instead of interpolating them into the command string
- Eliminates shell escaping issues with complex issue bodies containing backticks, dollar signs, nested code blocks, etc.
- Removes the now-unnecessary `escapeShell()` function

## Test plan
- [x] All 383 existing tests pass
- [x] ESLint passes
- [x] Build compiles successfully
- [ ] Verify triage stage works with a real issue containing markdown code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)