### PR TITLE
fix: use tools option instead of allowedTools and add stderr capture

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -121,16 +121,22 @@ const EDIT_TOOLS = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"];
 async function extractResult(prompt, anthropicKey, timeoutMs, allowEdits) {
     const abortController = new AbortController();
     const timer = setTimeout(() => abortController.abort(), timeoutMs);
+    const stderrChunks = [];
     try {
         let resultMessage;
         const stream = (0, claude_agent_sdk_1.query)({
             prompt,
             options: {
-                allowedTools: allowEdits ? EDIT_TOOLS : READ_ONLY_TOOLS,
+                tools: allowEdits ? EDIT_TOOLS : READ_ONLY_TOOLS,
                 permissionMode: "bypassPermissions",
                 allowDangerouslySkipPermissions: true,
+                persistSession: false,
                 abortController,
                 env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
+                stderr: (data) => {
+                    stderrChunks.push(data);
+                    core.debug(`Claude SDK stderr: ${data}`);
+                },
             },
         });
         for await (const message of stream) {
@@ -139,11 +145,14 @@ async function extractResult(prompt, anthropicKey, timeoutMs, allowEdits) {
             }
         }
         if (!resultMessage) {
-            throw new Error("No result received from Claude Agent SDK");
+            const stderr = stderrChunks.join("");
+            throw new Error(`No result received from Claude Agent SDK${stderr ? `\nstderr: ${stderr}` : ""}`);
         }
         if (resultMessage.subtype !== "success") {
             const errorResult = resultMessage;
-            throw new Error(errorResult.errors?.join("; ") || `Claude SDK error: ${resultMessage.subtype}`);
+            const stderr = stderrChunks.join("");
+            const baseMsg = errorResult.errors?.join("; ") || `Claude SDK error: ${resultMessage.subtype}`;
+            throw new Error(`${baseMsg}${stderr ? `\nstderr: ${stderr}` : ""}`);
         }
         return resultMessage.result.trim();
     }

--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -147,7 +147,7 @@ describe("invokeClaude", () => {
         expect.objectContaining({
           prompt: "Review this code",
           options: expect.objectContaining({
-            allowedTools: ["Read", "Glob", "Grep"],
+            tools: ["Read", "Glob", "Grep"],
           }),
         }),
       );
@@ -164,7 +164,7 @@ describe("invokeClaude", () => {
       expect(mockedQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           options: expect.objectContaining({
-            allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+            tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
           }),
         }),
       );
@@ -412,7 +412,7 @@ describe("runClaude", () => {
       expect.objectContaining({
         prompt: "test prompt",
         options: expect.objectContaining({
-          allowedTools: ["Read", "Glob", "Grep"],
+          tools: ["Read", "Glob", "Grep"],
         }),
       }),
     );
@@ -449,7 +449,7 @@ describe("runClaudeEdit", () => {
     expect(mockedQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+          tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
         }),
       }),
     );

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -42,6 +42,7 @@ async function extractResult(
 ): Promise<string> {
   const abortController = new AbortController();
   const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  const stderrChunks: string[] = [];
 
   try {
     let resultMessage: SDKResultMessage | undefined;
@@ -49,11 +50,16 @@ async function extractResult(
     const stream = query({
       prompt,
       options: {
-        allowedTools: allowEdits ? EDIT_TOOLS : READ_ONLY_TOOLS,
+        tools: allowEdits ? EDIT_TOOLS : READ_ONLY_TOOLS,
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
+        persistSession: false,
         abortController,
         env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
+        stderr: (data: string) => {
+          stderrChunks.push(data);
+          core.debug(`Claude SDK stderr: ${data}`);
+        },
       },
     });
 
@@ -64,12 +70,17 @@ async function extractResult(
     }
 
     if (!resultMessage) {
-      throw new Error("No result received from Claude Agent SDK");
+      const stderr = stderrChunks.join("");
+      throw new Error(
+        `No result received from Claude Agent SDK${stderr ? `\nstderr: ${stderr}` : ""}`,
+      );
     }
 
     if (resultMessage.subtype !== "success") {
       const errorResult = resultMessage as SDKResultMessage & { errors?: string[] };
-      throw new Error(errorResult.errors?.join("; ") || `Claude SDK error: ${resultMessage.subtype}`);
+      const stderr = stderrChunks.join("");
+      const baseMsg = errorResult.errors?.join("; ") || `Claude SDK error: ${resultMessage.subtype}`;
+      throw new Error(`${baseMsg}${stderr ? `\nstderr: ${stderr}` : ""}`);
     }
 
     return resultMessage.result.trim();


### PR DESCRIPTION
## Summary

- Use `tools` option (restricts available tool set) instead of `allowedTools` (auto-allows tools without prompts) — the previous config wasn't actually limiting which tools Claude could use
- Add `stderr` callback to capture diagnostic output from the SDK subprocess, so process exit failures include actionable error details
- Set `persistSession: false` to skip writing session data to disk in CI

## Test plan

- [x] `npm test` — all 381 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles successfully
- [ ] Trigger action on a test issue to confirm the fix resolves the `process exited with code 1` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)