### PR TITLE
fix: enrich SDK process errors with stderr output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -135,14 +135,26 @@ async function extractResult(prompt, anthropicKey, timeoutMs, allowEdits) {
                 env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
                 stderr: (data) => {
                     stderrChunks.push(data);
-                    core.debug(`Claude SDK stderr: ${data}`);
+                    core.warning(`Claude SDK stderr: ${data.trimEnd()}`);
                 },
             },
         });
-        for await (const message of stream) {
-            if (message.type === "result") {
-                resultMessage = message;
+        try {
+            for await (const message of stream) {
+                if (message.type === "result") {
+                    resultMessage = message;
+                }
             }
+        }
+        catch (streamError) {
+            // Re-throw AbortError as-is for timeout detection
+            if (streamError instanceof Error && streamError.name === "AbortError") {
+                throw streamError;
+            }
+            // Enrich other SDK process errors with captured stderr
+            const stderr = stderrChunks.join("");
+            const baseMsg = streamError instanceof Error ? streamError.message : String(streamError);
+            throw new Error(`${baseMsg}${stderr ? `\nstderr: ${stderr}` : ""}`);
         }
         if (!resultMessage) {
             const stderr = stderrChunks.join("");

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -58,15 +58,26 @@ async function extractResult(
         env: { ...process.env, ANTHROPIC_API_KEY: anthropicKey },
         stderr: (data: string) => {
           stderrChunks.push(data);
-          core.debug(`Claude SDK stderr: ${data}`);
+          core.warning(`Claude SDK stderr: ${data.trimEnd()}`);
         },
       },
     });
 
-    for await (const message of stream) {
-      if (message.type === "result") {
-        resultMessage = message as SDKResultMessage;
+    try {
+      for await (const message of stream) {
+        if (message.type === "result") {
+          resultMessage = message as SDKResultMessage;
+        }
       }
+    } catch (streamError) {
+      // Re-throw AbortError as-is for timeout detection
+      if (streamError instanceof Error && streamError.name === "AbortError") {
+        throw streamError;
+      }
+      // Enrich other SDK process errors with captured stderr
+      const stderr = stderrChunks.join("");
+      const baseMsg = streamError instanceof Error ? streamError.message : String(streamError);
+      throw new Error(`${baseMsg}${stderr ? `\nstderr: ${stderr}` : ""}`);
     }
 
     if (!resultMessage) {


### PR DESCRIPTION
## Summary

- Wrap the stream iteration in a try/catch to append captured stderr to the SDK's "process exited with code 1" error message
- Switch stderr callback from `core.debug` (hidden by default) to `core.warning` so subprocess output is always visible in GitHub Actions logs
- Re-throw AbortError as-is to preserve timeout detection

This is the missing commit from PR #8 that was pushed after merge.

## Test plan

- [x] `npm test` — all 381 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles successfully
- [ ] Trigger action on a test issue — if it fails again, error logs will now include stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)