### PR TITLE
fix: capture stderr from CLI errors for diagnostics

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -154,9 +154,7 @@ async function invokeClaude(prompt, config) {
         const isTimeout = error instanceof Error && error.code === "ETIMEDOUT";
         const errorMessage = isTimeout
             ? `Claude Code timed out after ${timeoutMinutes} minutes`
-            : error instanceof Error
-                ? error.message
-                : String(error);
+            : formatExecError(error);
         core.error(`Claude Code invocation failed: ${errorMessage}`);
         // Surface the error as a comment on the relevant issue/PR when possible
         await postErrorComment(errorMessage, octokit, context);
@@ -174,8 +172,7 @@ async function runClaude(prompt, options) {
         return execClaude(prompt, anthropicKey, timeoutMs, false);
     }
     catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        core.error(`Claude CLI failed: ${message}`);
+        core.error(`Claude CLI failed: ${formatExecError(error)}`);
         throw error;
     }
 }
@@ -190,10 +187,24 @@ async function runClaudeEdit(prompt, options) {
         return execClaude(prompt, anthropicKey, timeoutMs, true);
     }
     catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        core.error(`Claude CLI (edit) failed: ${message}`);
+        core.error(`Claude CLI (edit) failed: ${formatExecError(error)}`);
         throw error;
     }
+}
+/**
+ * Extract a useful error message from an execSync failure.
+ * The thrown error includes `stderr` with the actual CLI output.
+ */
+function formatExecError(error) {
+    if (!(error instanceof Error))
+        return String(error);
+    const execError = error;
+    const stderr = execError.stderr
+        ? typeof execError.stderr === "string"
+            ? execError.stderr.trim()
+            : execError.stderr.toString().trim()
+        : "";
+    return stderr || error.message;
 }
 /**
  * Post an error comment on the relevant issue or PR.

--- a/src/claude.test.ts
+++ b/src/claude.test.ts
@@ -147,6 +147,19 @@ describe("invokeClaude", () => {
       expect(result.output).toBe("");
     });
 
+    it("extracts stderr from execSync errors", async () => {
+      const error = new Error("Command failed: claude --print --dangerously-skip-permissions");
+      (error as Error & { stderr: string }).stderr = "Error: Invalid API key\n";
+      mockedExecSync.mockImplementation(() => { throw error; });
+
+      const result = await invokeClaude("prompt", {
+        anthropicKey: "sk-ant-test",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Error: Invalid API key");
+    });
+
     it("posts error comment on issue when octokit and context provided", async () => {
       mockedExecSync.mockImplementation(() => {
         throw new Error("API rate limited");

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -87,9 +87,7 @@ export async function invokeClaude(
       error instanceof Error && (error as NodeJS.ErrnoException).code === "ETIMEDOUT";
     const errorMessage = isTimeout
       ? `Claude Code timed out after ${timeoutMinutes} minutes`
-      : error instanceof Error
-        ? error.message
-        : String(error);
+      : formatExecError(error);
 
     core.error(`Claude Code invocation failed: ${errorMessage}`);
 
@@ -114,8 +112,7 @@ export async function runClaude(
   try {
     return execClaude(prompt, anthropicKey, timeoutMs, false);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    core.error(`Claude CLI failed: ${message}`);
+    core.error(`Claude CLI failed: ${formatExecError(error)}`);
     throw error;
   }
 }
@@ -134,10 +131,24 @@ export async function runClaudeEdit(
   try {
     return execClaude(prompt, anthropicKey, timeoutMs, true);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    core.error(`Claude CLI (edit) failed: ${message}`);
+    core.error(`Claude CLI (edit) failed: ${formatExecError(error)}`);
     throw error;
   }
+}
+
+/**
+ * Extract a useful error message from an execSync failure.
+ * The thrown error includes `stderr` with the actual CLI output.
+ */
+function formatExecError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const execError = error as Error & { stderr?: Buffer | string };
+  const stderr = execError.stderr
+    ? typeof execError.stderr === "string"
+      ? execError.stderr.trim()
+      : execError.stderr.toString().trim()
+    : "";
+  return stderr || error.message;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extract `stderr` from `execSync` error objects instead of just `.message`
- Previously errors showed only "Command failed: claude --print --dangerously-skip-permissions" with no detail
- Now surfaces the actual CLI error (e.g. "Error: Invalid API key")

## Test plan

- [x] `npm test` — 381 tests pass (added stderr extraction test)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Re-trigger on test issue to see actual error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)